### PR TITLE
Add contrib.auth urls to the main app urls

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -1,10 +1,11 @@
 """Urls module for the main app."""
 
-from django.urls import path
+from django.urls import include, path
 
 from . import views
 
 urlpatterns = [
     path("", views.index, name="index"),
     path("privacy/", views.privacy, name="privacy"),
+    path("accounts/", include("django.contrib.auth.urls")),
 ]


### PR DESCRIPTION
# Description

This PR adds the in-built Django authentication views to our urls so that they can be accessed. You will now see a `TemplateDoesNotExist` error when going to localhost/accounts/login instead of a 404

It is the first step required before all the templates in #65 can be done

Fixes #126 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
