### PR TITLE
Automatically approve bot PRs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,8 +11,15 @@ jobs:
   auto-merge:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
-    steps:
+    if: >-
+      ${{
+        github.event.pull_request.user.login == 'pre-commit-ci[bot]' ||
+        (
+          github.event.pull_request.user.login == 'dependabot[bot]' &&
+          contains(github.event.pull_request.title, 'pip')
+        )
+      }}
+      steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |
           gh pr review --approve "$PR_URL"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,9 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' || github.event.pull_request.user.login == 'pre-commit-ci[bot]' }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           # GitHub provides this variable in the CI env. You don't

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,14 +11,7 @@ jobs:
   auto-merge:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    if: >-
-      ${{
-        github.event.pull_request.user.login == 'pre-commit-ci[bot]' ||
-        (
-          github.event.pull_request.user.login == 'dependabot[bot]' &&
-          contains(github.event.pull_request.title, 'pip')
-        )
-      }}
+    if: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' || (github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.title, 'pip')) }}
     steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
           contains(github.event.pull_request.title, 'pip')
         )
       }}
-      steps:
+    steps:
       - name: Enable auto-merge for Dependabot PRs
         run: |
           gh pr review --approve "$PR_URL"


### PR DESCRIPTION
# Description

This PR will stop us needing to approve every single bot PR before they can be merged.

We can rely on the branch protection rules for preventing PRs that have broken dependencies.

Fixes #149 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
