### PR TITLE
Don't auto-merge GitHub Actions updates

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -11,9 +11,9 @@ jobs:
   auto-merge:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' || (github.event.pull_request.user.login == 'dependabot[bot]' && contains(github.event.pull_request.title, 'pip')) }}
+    if: ${{ github.event.pull_request.user.login == 'pre-commit-ci[bot]' || (github.event.pull_request.user.login == 'dependabot[bot]' && !contains(github.event.pull_request.title, 'action')) }}
     steps:
-      - name: Enable auto-merge for Dependabot PRs
+      - name: Enable auto-merge for Dependabot and pre-commit-ci PRs
         run: |
           gh pr review --approve "$PR_URL"
           gh pr merge --auto --merge "$PR_URL"


### PR DESCRIPTION
# Description

All dependabot updates are currently being skipped because the filter for only allowing titles containing "pip" is never true.

This reverses the logic so it doesn't apply the auto-merge workflow to the PRs containing the word "action" in the title. This is effectively the same logic that will allow only pip-dependencies to be automatically merged because GitHub Actions are the only other thing managed by dependabot

Related to https://github.com/RSEToolkit/rse-competencies-toolkit-webapp/pull/150#issuecomment-2654005259

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
