### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Key commands available in the `package.json`:
 ***Build All Assets:*** To build all styles, scripts, icon fonts, and vendor files, run:
 
 ```bash
-npm build
+npm run build
 ```
 
 ***Build Expanded Styles:*** To build expanded (human-readable) css files:


### PR DESCRIPTION
# Description

The npm command to run the build step in the readme is wrong

Close #148

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
