### PR TITLE
Add password_reset_confirm view

### DIFF
--- a/main/templates/registration/password_reset_confirm.html
+++ b/main/templates/registration/password_reset_confirm.html
@@ -1,29 +1,31 @@
 {% extends "../main/base.html" %}
 
 {% block content %}
-    {% if validlink %}
-        <p>Please enter (and confirm) your new password.</p>
-        <form action="" method="post">
-        {% csrf_token %}
-            <table>
-                <tr>
-                    <td>{{ form.new_password1.errors }}
-                        <label for="id_new_password1">New password:</label></td>
-                    <td>{{ form.new_password1 }}</td>
-                </tr>
-                <tr>
-                    <td>{{ form.new_password2.errors }}
-                        <label for="id_new_password2">Confirm password:</label></td>
-                    <td>{{ form.new_password2 }}</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><input type="submit" value="Change my password"></td>
-                </tr>
-            </table>
-        </form>
-    {% else %}
-        <h1>Password reset failed</h1>
-        <p>The password reset link was invalid, possibly because it has already been used. Please request a new password reset.</p>
-    {% endif %}
+    <section class="container pt-5 mt-5">
+        {% if validlink %}
+            <p>Please enter (and confirm) your new password.</p>
+            <form action="" method="post">
+            {% csrf_token %}
+                <table>
+                    <tr>
+                        <td>{{ form.new_password1.errors }}
+                            <label for="id_new_password1">New password:</label></td>
+                        <td>{{ form.new_password1 }}</td>
+                    </tr>
+                    <tr>
+                        <td>{{ form.new_password2.errors }}
+                            <label for="id_new_password2">Confirm password:</label></td>
+                        <td>{{ form.new_password2 }}</td>
+                    </tr>
+                    <tr>
+                        <td></td>
+                        <td><input type="submit" value="Change my password"></td>
+                    </tr>
+                </table>
+            </form>
+        {% else %}
+            <h1>Password reset failed</h1>
+            <p>The password reset link was invalid, possibly because it has already been used. Please request a new password reset.</p>
+        {% endif %}
+    </section>
 {% endblock %}

--- a/main/templates/registration/password_reset_confirm.html
+++ b/main/templates/registration/password_reset_confirm.html
@@ -1,0 +1,29 @@
+{% extends "../main/base.html" %}
+
+{% block content %}
+    {% if validlink %}
+        <p>Please enter (and confirm) your new password.</p>
+        <form action="" method="post">
+        {% csrf_token %}
+            <table>
+                <tr>
+                    <td>{{ form.new_password1.errors }}
+                        <label for="id_new_password1">New password:</label></td>
+                    <td>{{ form.new_password1 }}</td>
+                </tr>
+                <tr>
+                    <td>{{ form.new_password2.errors }}
+                        <label for="id_new_password2">Confirm password:</label></td>
+                    <td>{{ form.new_password2 }}</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><input type="submit" value="Change my password"></td>
+                </tr>
+            </table>
+        </form>
+    {% else %}
+        <h1>Password reset failed</h1>
+        <p>The password reset link was invalid, possibly because it has already been used. Please request a new password reset.</p>
+    {% endif %}
+{% endblock %}

--- a/tests/main/test_registration_views.py
+++ b/tests/main/test_registration_views.py
@@ -1,8 +1,7 @@
 # from django.core import mail
-import re
-
 from django.core import mail
 from django.test import TestCase
+from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
 from main.models import User
@@ -30,48 +29,90 @@ class TestRegistrationViews(TestCase):
             username="testuser",
         )
 
-    # Password reset tests
     def test_password_reset(self):
         """Test the password_reset_form view."""
         with assertTemplateUsed(template_name="registration/password_reset_form.html"):
             response = self.client.get("/accounts/password_reset/")
         self.assertEqual(response.status_code, 200)
 
-    def test_password_reset_submit(self):
-        """Tests the templates are used when a password reset email is requested."""
-        response = self.client.post(
-            path="/accounts/password_reset/", data={"email": self.test_user.email}
-        )
-
-        # Assert redirects to password_reset/done
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.url, "/accounts/password_reset/done/")
-
-        # Verify the generated email against the expected template
-        with open("main/templates/registration/password_reset_subject.txt") as f:
-            expected_email_subject = f.read()
-
-        with open("main/templates/registration/password_reset_email.html") as f:
-            expected_email_body = f.read()
-        expected_email_body = re.sub(
-            "\{\{ email \}\}", self.test_user.email, expected_email_body
-        )
-        expected_email_body = re.sub("\{\{ protocol \}\}", "http", expected_email_body)
-        expected_email_body = re.sub(
-            "\{\{ domain \}\}", "testserver", expected_email_body
-        )
-        expected_email_body = re.sub("\{\%.*\%\}", "", expected_email_body)
-
-        self.assertEqual(len(mail.outbox), 1)
-        actual_email = mail.outbox[0]
-        self.assertEqual(actual_email.subject, expected_email_subject.strip())
-        self.assertRegex(actual_email.body, f"{expected_email_body.strip()}.*")
-
-    # ------------------------------------------------------------
-
-    # Password reset done tests
     def test_password_reset_done(self):
         """Test the password_reset_done view."""
         with assertTemplateUsed(template_name="registration/password_reset_done.html"):
             response = self.client.get("/accounts/password_reset/done/")
         self.assertEqual(response.status_code, 200)
+
+    def test_reset_flow(self):
+        """Test the password_reset_confirm view.
+
+        There are more steps here as the user is redirected
+        to the password_reset_confirm view from the email link.
+
+        This test also verifies the email templates are used when a
+        password reset email is requested.
+        """
+        # Request a password reset email
+        response = self.client.post(
+            path="/accounts/password_reset/", data={"email": self.test_user.email}
+        )
+        # Assert redirects to password_reset/done
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/accounts/password_reset/done/")
+
+        # Get the token and userid from the response
+        token = response.context[0]["token"]
+        uid = response.context[0]["uid"]
+        generated_reset_url = reverse(
+            "password_reset_confirm", kwargs={"token": token, "uidb64": uid}
+        )
+        set_password_url = f"/accounts/reset/{uid}/set-password/"
+
+        # Verify the generated email against the expected templates
+        with open("main/templates/registration/password_reset_subject.txt") as f:
+            expected_email_subject = f.read()
+        with open("main/templates/registration/password_reset_email.html") as f:
+            expected_email_content = f.read()
+            # Replace template variables
+            expected_email_content = expected_email_content.replace(
+                "{{ email }}", self.test_user.email
+            )
+            expected_email_content = expected_email_content.replace(
+                "{{ protocol }}", "http"
+            )
+            expected_email_content = expected_email_content.replace(
+                "{{ domain }}", "testserver"
+            )
+            expected_email_content = expected_email_content.replace(
+                "{% url 'password_reset_confirm' uidb64=uid token=token %}",
+                generated_reset_url,
+            )
+
+        self.assertEqual(len(mail.outbox), 1)
+        generated_email = mail.outbox[0]
+        self.assertEqual(generated_email.subject, expected_email_subject.strip())
+        self.assertEqual(generated_email.body.strip(), expected_email_content.strip())
+
+        # Now we can use the token to get the password change form
+        response = self.client.get(generated_reset_url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, set_password_url)
+
+        # Expect out custom error page if an incorrect token/uid is used
+        with assertTemplateUsed(
+            template_name="registration/password_reset_confirm.html"
+        ):
+            response = self.client.get(
+                reverse(
+                    "password_reset_confirm",
+                    kwargs={"token": "some", "uidb64": "thing"},
+                )
+            )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Password reset failed")
+
+        # Expect our custom password_reset_confirm page
+        with assertTemplateUsed(
+            template_name="registration/password_reset_confirm.html"
+        ):
+            response = self.client.get(set_password_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Password reset failed")


### PR DESCRIPTION
# Description

Adds the simple django example template for the password_reset_confirm view

Fixes #135  

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
