### PR TITLE
Add template for logout view [#130]

### DIFF
--- a/main/templates/main/snippets/navbar.html
+++ b/main/templates/main/snippets/navbar.html
@@ -25,11 +25,21 @@
         <i class="ai-moon fs-lg"></i>
       </label>
     </div>
+    {% if user.is_authenticated %}
+    <form action="{% url 'logout' %}" method="post">
+      {% csrf_token %}
+      <button class="btn btn-primary btn-sm fs-sm order-lg-3 d-none d-sm-inline-flex" type="submit">
+        <i class="ai-logout fs-xl me-2 ms-n1"></i>
+        Log Out
+      </button>
+    </form>
+    {% else %}
     <a class="btn btn-primary btn-sm fs-sm order-lg-3 d-none d-sm-inline-flex"
        href="{% url 'login' %}">
       <i class="ai-login fs-xl me-2 ms-n1"></i>
       Login
     </a>
+    {% endif %}
     <!-- Mobile menu toggler (Hamburger) -->
     <button class="navbar-toggler ms-sm-3"
             type="button"

--- a/main/templates/main/snippets/navbar.html
+++ b/main/templates/main/snippets/navbar.html
@@ -26,19 +26,21 @@
       </label>
     </div>
     {% if user.is_authenticated %}
-    <form action="{% url 'logout' %}" method="post">
-      {% csrf_token %}
-      <button class="btn btn-primary btn-sm fs-sm order-lg-3 d-none d-sm-inline-flex" type="submit">
-        <i class="ai-logout fs-xl me-2 ms-n1"></i>
-        Log Out
-      </button>
-    </form>
+      <form action="{% url 'logout' %}"
+            method="post"
+            class="order-lg-3 d-none d-sm-inline-flex">
+        {% csrf_token %}
+        <button class="btn btn-primary btn-sm fs-sm" type="submit">
+          <i class="ai-logout fs-xl me-2 ms-n1"></i>
+          Log Out
+        </button>
+      </form>
     {% else %}
-    <a class="btn btn-primary btn-sm fs-sm order-lg-3 d-none d-sm-inline-flex"
-       href="{% url 'login' %}">
-      <i class="ai-login fs-xl me-2 ms-n1"></i>
-      Login
-    </a>
+      <a class="btn btn-primary btn-sm fs-sm order-lg-3 d-none d-sm-inline-flex"
+         href="{% url 'login' %}">
+        <i class="ai-login fs-xl me-2 ms-n1"></i>
+        Login
+      </a>
     {% endif %}
     <!-- Mobile menu toggler (Hamburger) -->
     <button class="navbar-toggler ms-sm-3"

--- a/main/templates/registration/logged_out.html
+++ b/main/templates/registration/logged_out.html
@@ -1,0 +1,11 @@
+{% extends "main/base.html" %}
+
+{% block content %}
+
+<section class="container pt-5 mt-5">
+
+  <p>You are now logged out.</p>
+
+</section>
+
+{% endblock content %}

--- a/rse_competencies_toolkit/settings/settings.py
+++ b/rse_competencies_toolkit/settings/settings.py
@@ -124,7 +124,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
 # Custom settings
-INSTALLED_APPS += ["main"]
+INSTALLED_APPS = ["main", *INSTALLED_APPS]
 
 
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")

--- a/rse_competencies_toolkit/settings/settings.py
+++ b/rse_competencies_toolkit/settings/settings.py
@@ -124,6 +124,8 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 
 # Custom settings
+
+# List main app first so that custom templates override default admin views
 INSTALLED_APPS = ["main", *INSTALLED_APPS]
 
 


### PR DESCRIPTION
# Description

_Please include a summary of the change and which issue is fixed (if any). Please also
include relevant motivation and context. List any dependencies that are required for
this change._

This PR builds on the changes in #187.

- Add logged_out page template
- Adapt navbar to display login/logout buttons as appropriate
- Ensure that main app is listed ahead of default Django apps to ensure that default admin views do not override registration templates

Fixes #130

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
