### PR TITLE
Fix incorrect instructions for populating the db

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ To get started:
 8. To populate the db with Categories and Skills from a yaml or json version of the framework
 
    ```bash
-   python scripts/populate_db.py [-j data.json]|[-y data.yaml]
+   python -m scripts.populate_db [-j data.json]|[-y data.yaml]
    ```
 
 ### Installation with Docker


### PR DESCRIPTION
# Description

The instructions for how to run the populate_db script did not work. This updates to a working command.

## Type of change

- [x] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
