### PR TITLE
Update permissions in Dockerfile for nobody user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,8 @@ RUN pip install -r /requirements.txt
 EXPOSE 8000
 COPY --chown=nobody:nogroup . /usr/src/app
 WORKDIR /usr/src/app
+
+RUN chown -R nobody:nogroup /usr/src/app \
+ && chmod -R +r /usr/src/app
+
 USER nobody


### PR DESCRIPTION
# Description

This PR adds permissions in the dockerfile so the nobody user can run the app

This needs to be checked by someone who can reproduce the original bug - described in #305

Fixes #305

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
