### PR TITLE
Correct hostname in azure deployment

### DIFF
--- a/direct_webapp/settings/azure.py
+++ b/direct_webapp/settings/azure.py
@@ -20,7 +20,7 @@ DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL", "webmaster@localhost")
 # -----------------------------------------------------------------------------
 # Set allowed hosts explicitly for production
 ALLOWED_HOSTS = [
-    "https://directframework.com",
+    "directframework.com",
     "direct-c8ctfkd4btcecqde.ukwest-01.azurewebsites.net",
 ]
 


### PR DESCRIPTION
# Description

Correct bug in allowed hosts by removing the `https` protocol. It should just be the host name. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
