### PR TITLE
Remove get_context_data method from view

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -295,22 +295,6 @@ class SelfAssessPageView(LoginRequiredMixin, FormView[UserSkillsForm]):
     form_class = UserSkillsForm
     success_url = reverse_lazy("self_assess")
 
-    def get_context_data(self, **kwargs: Mapping[str, object]) -> dict[str, object]:
-        """Add the competencies framework data to the template context."""
-        context = super().get_context_data(**kwargs)
-        json_path = Path("data/skills-competencies-framework.json")
-        with open(json_path) as f:
-            framework = json.load(f)
-
-        for category in framework.get("categories", []):
-            category["competency_count"] = len(category.get("subcategories", []))
-            category["skill_count"] = sum(
-                len(sub.get("skills", [])) for sub in category.get("subcategories", [])
-            )
-
-        context["framework"] = framework
-        return context
-
     def get_form_kwargs(self) -> dict[str, Any]:
         """Return the keyword arguments for instantiating the form."""
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
Removed the get_context_data method that added competencies framework data to the template context.

# Description

_Please include a summary of the change and which issue is fixed (if any). Please also
include relevant motivation and context. List any dependencies that are required for
this change._

Fixes https://github.com/direct-framework/direct-webapp/issues/545

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
