### PR TITLE
Re-compile and update the requirements files

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -63,7 +63,9 @@ editorconfig==0.17.1
     #   cssbeautifier
     #   jsbeautifier
 filelock==3.25.0
-    # via virtualenv
+    # via
+    #   python-discovery
+    #   virtualenv
 gunicorn==25.1.0
     # via direct_webapp (pyproject.toml)
 identify==2.6.16
@@ -101,7 +103,9 @@ pathspec==1.0.4
 pip-tools==7.5.3
     # via direct_webapp (pyproject.toml)
 platformdirs==4.9.2
-    # via virtualenv
+    # via
+    #   python-discovery
+    #   virtualenv
 pluggy==1.6.0
     # via
     #   pytest
@@ -126,6 +130,8 @@ pytest-django==4.12.0
     # via direct_webapp (pyproject.toml)
 pytest-mock==3.15.1
     # via direct_webapp (pyproject.toml)
+python-discovery==1.1.3
+    # via virtualenv
 pyyaml==6.0.3
     # via
     #   djlint

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -17,9 +17,7 @@ charset-normalizer==3.4.4
 click==8.3.1
     # via mkdocs
 colorama==0.4.6
-    # via
-    #   griffe
-    #   mkdocs-material
+    # via mkdocs-material
 confusable-homoglyphs==3.3.1
     # via django-registration
 crispy-bootstrap5==2026.3
@@ -49,7 +47,7 @@ django-stubs-ext==5.2.9
     # via direct_webapp (pyproject.toml)
 ghp-import==2.1.0
     # via mkdocs
-griffe==2.0.0
+griffelib==2.0.0
     # via mkdocstrings-python
 gunicorn==25.1.0
     # via direct_webapp (pyproject.toml)


### PR DESCRIPTION
# Description

I got a really unexpected failure in pre-commit and realised it's because I had used `pip-sync` with the requirements files and there was a new package missing required for virtualenv called `python_discovery`. It is needed for `virtualenv>=21.0`.

So I have re-run `pip-compile` to ensure we have everything we need.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
