### PR TITLE
Trying a new access token to fix contributors workflow error

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,7 +2,7 @@ name: Add Contributors
 
 on:
   push:
-    branches: [main]
+    branches: [main, 624-contr-bug]
 
 jobs:
   contributors:


### PR DESCRIPTION
# Description

Use the new token that has been added to secrets for the contributors workflow.

Fixes #624 

Note: opening in draft because this alone does not fix the issue. I have opened some PRs in the upstream repos to try and fix this:
- https://github.com/JoshuaKGoldberg/all-contributors-for-repository/pull/1096
- https://github.com/JoshuaKGoldberg/all-contributors-for-repository/pull/1097

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
