### PR TITLE
Restrict mkdocs version to < 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dev = [
     "types-django-import-export",
 ]
 doc = [
-    "mkdocs",
+    "mkdocs<2",
     "mkdocstrings",
     "mkdocstrings-python",
     "mkdocs-material",


### PR DESCRIPTION
# Description

MkDocs 2.0 is coming and it will be incompatible with Mkdocs-material, which we use for the developer docs. For now, pin the version of mkdocs to prevent an automatic update

https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
