### PR TITLE
Redirect to a Terms and conditions form

### DIFF
--- a/main/forms.py
+++ b/main/forms.py
@@ -22,6 +22,16 @@ if TYPE_CHECKING:  # pragma: no cover
     from .models import User as UserType
 
 
+def _build_tos_form_label() -> str:
+    html_anchor = '<a href="{}" target="_blank" rel="noopener noreferrer">'
+    return format_html(
+        f"I have read and agree to the {html_anchor} Terms and Conditions</a>"
+        f" and {html_anchor}Privacy Policy</a>.",
+        reverse("terms"),
+        reverse("privacy"),
+    )
+
+
 class RegistrationForm(RegistrationFormUniqueEmail, RegistrationFormTermsOfService):
     """Inherit from provided Registration Forms to include additional fields.
 
@@ -33,15 +43,7 @@ class RegistrationForm(RegistrationFormUniqueEmail, RegistrationFormTermsOfServi
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Override the constructor to include links in the `tos` field label."""
         super().__init__(*args, **kwargs)
-        html_anchor = '<a href="{}" target="_blank" rel="noopener noreferrer">'
-        self.fields["tos"].label = _(
-            format_html(
-                f"I have read and agree to the {html_anchor} Terms and Conditions</a>"
-                f" and {html_anchor}Privacy Policy</a>.",
-                reverse("terms"),
-                reverse("privacy"),
-            )
-        )
+        self.fields["tos"].label = _(_build_tos_form_label())
 
     def clean(self) -> dict[str, Any] | None:
         """Ensure that the Terms are agreed to and assign them to the user instance."""
@@ -58,6 +60,17 @@ class RegistrationForm(RegistrationFormUniqueEmail, RegistrationFormTermsOfServi
         self.instance.agreed_to_tos = agreed
         self.instance.date_agreed = timezone.now()
         return super().clean()
+
+
+class TermsAcceptanceForm(forms.Form):
+    """Simple form that requires terms acceptance for existing users."""
+
+    tos = forms.BooleanField(required=True)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Include links to terms and privacy pages in the checkbox label."""
+        super().__init__(*args, **kwargs)
+        self.fields["tos"].label = _(_build_tos_form_label())
 
 
 class UserSkillForm(ModelForm[UserSkill]):

--- a/main/templates/main/terms_acceptance.html
+++ b/main/templates/main/terms_acceptance.html
@@ -1,0 +1,13 @@
+{% extends "main/base.account.html" %}
+{% load crispy_forms_tags %}
+{% block content %}
+    <section class="container">
+        <h1>Accept Terms and Privacy Policy</h1>
+        <p class="mb-3">You need to accept the Terms and Conditions and Privacy Policy before using your account pages.</p>
+        <form method="post">
+            {% csrf_token %}
+            {{ form|crispy }}
+            <button type="submit" class="btn btn-primary">Continue</button>
+        </form>
+    </section>
+{% endblock content %}

--- a/main/templates/main/terms_acceptance.html
+++ b/main/templates/main/terms_acceptance.html
@@ -2,8 +2,10 @@
 {% load crispy_forms_tags %}
 {% block content %}
     <section class="container">
-        <h1>Accept Terms and Privacy Policy</h1>
-        <p class="mb-3">You need to accept the Terms and Conditions and Privacy Policy before using your account pages.</p>
+        <h1>Terms and Privacy Policy</h1>
+        <p class="mb-3">
+            To continue using your account, please review and accept our latest Terms and Conditions and Privacy Policy.
+        </p>
         <form method="post">
             {% csrf_token %}
             {{ form|crispy }}

--- a/main/urls.py
+++ b/main/urls.py
@@ -46,6 +46,11 @@ urlpatterns = [
     path("accounts/", include(accounts_patterns)),
     path("about/", views.AboutPageView.as_view(), name="about"),
     path("terms/", views.TermsPageView.as_view(), name="terms"),
+    path(
+        "terms-acceptance/",
+        views.TermsAcceptanceView.as_view(),
+        name="terms_acceptance",
+    ),
     path("framework/", include(framework_patterns)),
     path("get-involved/", views.GetInvolvedPageView.as_view(), name="get_involved"),
     path("events/", views.EventsPageView.as_view(), name="events"),

--- a/main/views/account_views.py
+++ b/main/views/account_views.py
@@ -2,18 +2,20 @@
 
 import logging
 from json import dumps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from django.contrib import messages
 from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.forms import ModelForm
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.http.response import HttpResponseBase
 from django.urls import reverse, reverse_lazy
+from django.utils import timezone
 from django.views.generic.base import RedirectView, TemplateView
 from django.views.generic.edit import FormView, UpdateView
 
-from ..forms import UserSkillsForm
+from ..forms import TermsAcceptanceForm, UserSkillsForm
 from ..models import SkillLevel, UserSkill
 
 logger = logging.getLogger(__name__)
@@ -31,7 +33,45 @@ class AuthenticatedHttpRequest(HttpRequest):
 User = get_user_model()
 
 
-class SkillProfileView(LoginRequiredMixin, TemplateView):
+class TermsAcceptedMixin(LoginRequiredMixin):
+    """Require authenticated users to accept terms before accessing account pages."""
+
+    terms_acceptance_url_name = "terms_acceptance"
+
+    def dispatch(
+        self, request: HttpRequest, *args: Any, **kwargs: Any
+    ) -> HttpResponseBase:
+        """Redirect to terms acceptance page when the user has not accepted terms."""
+        if not request.user.is_authenticated:
+            return self.handle_no_permission()
+
+        if request.user.agreed_to_tos:
+            return super().dispatch(request, *args, **kwargs)
+
+        resolver_match = request.resolver_match
+        if resolver_match and resolver_match.url_name == self.terms_acceptance_url_name:
+            return super().dispatch(request, *args, **kwargs)
+
+        return HttpResponseRedirect(reverse(self.terms_acceptance_url_name))
+
+
+class TermsAcceptanceView(LoginRequiredMixin, FormView[TermsAcceptanceForm]):
+    """Prompt authenticated users to accept terms before continuing."""
+
+    template_name = "main/terms_acceptance.html"
+    form_class = TermsAcceptanceForm
+    success_url = reverse_lazy("account-overview")
+
+    def form_valid(self, form: TermsAcceptanceForm) -> HttpResponse:
+        """Persist acceptance and the acceptance timestamp."""
+        user = cast("UserType", self.request.user)
+        user.agreed_to_tos = form.cleaned_data["tos"]
+        user.date_agreed = timezone.now()
+        user.save(update_fields=["agreed_to_tos", "date_agreed"])
+        return HttpResponseRedirect(str(self.success_url))
+
+
+class SkillProfileView(TermsAcceptedMixin, TemplateView):
     """View that renders the skill profile page."""
 
     request: AuthenticatedHttpRequest
@@ -67,7 +107,7 @@ class SkillProfileView(LoginRequiredMixin, TemplateView):
         return context
 
 
-class AccountOverviewView(LoginRequiredMixin, RedirectView):
+class AccountOverviewView(TermsAcceptedMixin, RedirectView):
     """Route users to the appropriate account page based on their skills."""
 
     request: AuthenticatedHttpRequest
@@ -79,12 +119,12 @@ class AccountOverviewView(LoginRequiredMixin, RedirectView):
         return reverse("self_assess")
 
 
-class UserUpdateView(LoginRequiredMixin, UpdateView["UserType", ModelForm["UserType"]]):
+class UserUpdateView(TermsAcceptedMixin, UpdateView["UserType", ModelForm["UserType"]]):
     """View that renders the user update form page."""
 
     request: AuthenticatedHttpRequest
     model = User
-    fields = ("username", "email")
+    fields = ("username", "email", "first_name", "last_name")
     template_name_suffix = "-update-form"
     success_url = reverse_lazy("profile")
 
@@ -93,7 +133,7 @@ class UserUpdateView(LoginRequiredMixin, UpdateView["UserType", ModelForm["UserT
         return self.request.user
 
 
-class SelfAssessPageView(LoginRequiredMixin, FormView[UserSkillsForm]):
+class SelfAssessPageView(TermsAcceptedMixin, FormView[UserSkillsForm]):
     """View that renders the self-assessment questionnaire page."""
 
     request: AuthenticatedHttpRequest

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -8,7 +8,6 @@ from json import dumps
 from pathlib import Path
 from typing import Any
 
-from django.contrib.auth import get_user_model
 from django.shortcuts import get_object_or_404
 from django.templatetags.static import static
 from django.views.generic.base import TemplateView
@@ -16,8 +15,6 @@ from django.views.generic.base import TemplateView
 from ..models import CompetencyDomain, Skill, SkillLevel, ToolLanguageMethodology
 
 logger = logging.getLogger(__name__)
-
-User = get_user_model()
 
 
 def _extract_and_combine_roles(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,13 @@ def user(django_user_model):
         email="test.user@mail.com",
         password="1234",
         username="testuser",
+        agreed_to_tos=True,
     )
+
+
+@pytest.fixture
+def admin_user(admin_user):
+    """Override admin_user fixture to keep admin-client access to gated pages."""
+    admin_user.agreed_to_tos = True
+    admin_user.save()
+    return admin_user

--- a/tests/main/test_forms.py
+++ b/tests/main/test_forms.py
@@ -6,7 +6,7 @@ import pytest
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
-from main.forms import RegistrationForm
+from main.forms import RegistrationForm, TermsAcceptanceForm
 
 
 @pytest.fixture
@@ -88,3 +88,20 @@ def test_registration_form_rejects_duplicate_email(
 
     assert not form.is_valid()
     assert "email" in form.errors
+
+
+def test_terms_acceptance_form_tos_label_includes_terms_and_privacy_links() -> None:
+    """The acceptance form tos label should include terms/privacy links."""
+    form = TermsAcceptanceForm()
+
+    label = str(form.fields["tos"].label)
+    assert reverse("terms") in label
+    assert reverse("privacy") in label
+
+
+def test_terms_acceptance_form_requires_tos() -> None:
+    """The acceptance form should require the checkbox to be ticked."""
+    form = TermsAcceptanceForm(data={"tos": False})
+
+    assert not form.is_valid()
+    assert "tos" in form.errors

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -299,7 +299,7 @@ class TestSelfAssessPageView(TemplateOkMixin, LoginRequiredMixin):
 
 @pytest.mark.parametrize(
     "url_name",
-    ["skill_profile", "self_assess", "profile", "account-overview"],
+    ["skills_profile", "self_assess", "profile", "account-overview"],
 )
 def test_unaccepted_users_are_redirected_to_terms_acceptance(client, user, url_name):
     """Unaccepted users should be redirected from gated account pages."""

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -218,6 +218,40 @@ class TestTermsPageView(TemplateOkMixin):
         return reverse("terms")
 
 
+class TestTermsAcceptanceView(TemplateOkMixin, LoginRequiredMixin):
+    """Test suite for the terms acceptance view."""
+
+    _template_name = "main/terms_acceptance.html"
+
+    def _get_url(self):
+        return reverse("terms_acceptance")
+
+    def test_post_updates_user_and_redirects_to_overview(self, client, user):
+        """Test that posting acceptance updates user fields and redirects."""
+        user.agreed_to_tos = False
+        user.save(update_fields=["agreed_to_tos"])
+        client.force_login(user)
+
+        response = client.post(self._get_url(), data={"tos": True})
+
+        user.refresh_from_db()
+        assert user.agreed_to_tos is True
+        assert user.date_agreed is not None
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("account-overview")
+
+    def test_post_redirects_to_overview_without_next(self, client, user):
+        """Test that posting acceptance without next redirects to account overview."""
+        user.agreed_to_tos = False
+        user.save(update_fields=["agreed_to_tos"])
+        client.force_login(user)
+
+        response = client.post(self._get_url(), data={"tos": True})
+
+        assert response.status_code == HTTPStatus.FOUND
+        assert response.url == reverse("account-overview")
+
+
 class TestSelfAssessPageView(TemplateOkMixin, LoginRequiredMixin):
     """Test suite for the SelfAssessPageView."""
 
@@ -261,6 +295,23 @@ class TestSelfAssessPageView(TemplateOkMixin, LoginRequiredMixin):
         # Assert redirects to self_assess (success_url)
         assert response.status_code == HTTPStatus.FOUND
         assert response.url == reverse("self_assess")
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    ["skill_profile", "self_assess", "profile", "account-overview"],
+)
+def test_unaccepted_users_are_redirected_to_terms_acceptance(client, user, url_name):
+    """Unaccepted users should be redirected from gated account pages."""
+    user.agreed_to_tos = False
+    user.save(update_fields=["agreed_to_tos"])
+    client.force_login(user)
+    target_url = reverse(url_name)
+
+    response = client.get(target_url)
+
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.url == reverse("terms_acceptance")
 
 
 class TestUserSkillProfile(TemplateOkMixin, BS4Mixin):


### PR DESCRIPTION
# Description

This PR builds on #677 by adding a redirect to a form that allows users to accept the terms and conditions if they have not done so


## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
