### PR TITLE
Learning resources page

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,6 +42,7 @@ repos:
           - django-import-export
           - types-django-import-export
           - django-multiselectfield
+          - django-tables2
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.48.0
     hooks:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -41,6 +41,7 @@ django==6.0.3
     #   django-registration
     #   django-stubs
     #   django-stubs-ext
+    #   django-tables2
 django-bootstrap5==26.2
     # via direct_webapp (pyproject.toml)
 django-crispy-forms==2.6
@@ -61,6 +62,8 @@ django-stubs-ext==6.0.2
     # via
     #   direct_webapp (pyproject.toml)
     #   django-stubs
+django-tables2==3.0.0
+    # via direct_webapp (pyproject.toml)
 djlint==1.36.4
     # via direct_webapp (pyproject.toml)
 editorconfig==0.17.1

--- a/direct_webapp/settings/settings.py
+++ b/direct_webapp/settings/settings.py
@@ -127,6 +127,7 @@ INSTALLED_APPS = [
     "crispy_forms",
     "crispy_bootstrap5",
     "import_export",
+    "django_tables2",
 ]
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")
 STATIC_ROOT = BASE_DIR / "staticfiles"
@@ -137,6 +138,8 @@ SITE_TITLE = "DIRECT Framework"
 
 CRISPY_ALLOWED_TEMPLATE_PACKS = "bootstrap5"
 CRISPY_TEMPLATE_PACK = "bootstrap5"
+
+DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5-responsive.html"
 
 # Ensure the logs directory exists
 LOGS_DIR = BASE_DIR / "logs"

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -15,7 +15,9 @@ certifi==2026.2.25
 charset-normalizer==3.4.6
     # via requests
 click==8.3.1
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   properdocs
 colorama==0.4.6
     # via mkdocs-material
 confusable-homoglyphs==3.3.1
@@ -34,6 +36,7 @@ django==6.0.3
     #   django-multiselectfield
     #   django-registration
     #   django-stubs-ext
+    #   django-tables2
 django-bootstrap5==26.2
     # via direct_webapp (pyproject.toml)
 django-crispy-forms==2.6
@@ -48,8 +51,12 @@ django-registration==5.2.1
     # via direct_webapp (pyproject.toml)
 django-stubs-ext==6.0.2
     # via direct_webapp (pyproject.toml)
+django-tables2==3.0.0
+    # via direct_webapp (pyproject.toml)
 ghp-import==2.1.0
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   properdocs
 griffelib==2.0.2
     # via mkdocstrings-python
 gunicorn==25.3.0
@@ -61,12 +68,14 @@ jinja2==3.1.6
     #   mkdocs
     #   mkdocs-material
     #   mkdocstrings
+    #   properdocs
 markdown==3.10.2
     # via
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocs-material
     #   mkdocstrings
+    #   properdocs
     #   pymdown-extensions
 markupsafe==3.0.3
     # via
@@ -74,6 +83,7 @@ markupsafe==3.0.3
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocstrings
+    #   properdocs
 mergedeep==1.3.4
     # via
     #   mkdocs
@@ -115,12 +125,22 @@ packaging==26.0
     # via
     #   gunicorn
     #   mkdocs
+    #   properdocs
 paginate==0.5.7
     # via mkdocs-material
 pathspec==1.0.4
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   properdocs
 platformdirs==4.9.4
-    # via mkdocs-get-deps
+    # via
+    #   mkdocs-get-deps
+    #   properdocs
+properdocs==1.6.7
+    # via
+    #   mkdocs-gen-files
+    #   mkdocs-literate-nav
+    #   mkdocs-section-index
 pygments==2.20.0
     # via mkdocs-material
 pymdown-extensions==10.21.2
@@ -133,10 +153,13 @@ pyyaml==6.0.3
     # via
     #   mkdocs
     #   mkdocs-get-deps
+    #   properdocs
     #   pymdown-extensions
     #   pyyaml-env-tag
 pyyaml-env-tag==1.1
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   properdocs
 requests==2.33.1
     # via mkdocs-material
 six==1.17.0
@@ -150,6 +173,8 @@ typing-extensions==4.15.0
 urllib3==2.6.3
     # via requests
 watchdog==6.0.0
-    # via mkdocs
+    # via
+    #   mkdocs
+    #   properdocs
 whitenoise==6.12.0
     # via direct_webapp (pyproject.toml)

--- a/main/tables.py
+++ b/main/tables.py
@@ -1,0 +1,61 @@
+"""Tables module for the main app."""
+
+from typing import TYPE_CHECKING
+
+import django_tables2 as tables
+from django.urls import reverse
+from django.utils.html import format_html
+from django.utils.safestring import SafeString, mark_safe
+
+from .models import LearningResource, Skill
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.db.models.fields.related_descriptors import ManyRelatedManager
+
+
+class LearningResourcesTable(tables.Table):
+    """Table class for the LearningResources model."""
+
+    skill_set = tables.ManyToManyColumn(
+        transform=lambda s: s.name, verbose_name="Related Skills"
+    )
+
+    class Meta:
+        """Meta options for the LearningResourcesTable."""
+
+        model = LearningResource
+        fields = ("name", "language", "provider")
+        order_by = "name"
+
+    def render_name(self, value: str, record: LearningResource) -> SafeString:
+        """Include the URL in the name."""
+        return format_html(
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}<a>',
+            record.url,
+            value,
+        )
+
+    def render_provider(self, value: str, record: LearningResource) -> SafeString:
+        """Include the URL in the provider name."""
+        if record.provider is None or not record.provider.url:
+            return mark_safe(value)
+
+        return format_html(
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}<a>',
+            record.provider.url,
+            value,
+        )
+
+    def render_skill_set(self, value: "ManyRelatedManager[Skill]") -> SafeString:
+        """Include the related skills as badges."""
+        return mark_safe(
+            "".join(
+                format_html(
+                    '<a href="{}" target="_blank" rel="noopener noreferrer" '
+                    'class="badge bg-secondary">{}<a>',
+                    reverse("skill_detail", args=(skill.slug,)),
+                    skill.name,
+                )
+                for skill in value.all()
+            )
+        )

--- a/main/tables.py
+++ b/main/tables.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class LearningResourcesTable(tables.Table):
     """Table class for the LearningResources model."""
 
-    skill_set = tables.ManyToManyColumn(verbose_name="Related Skills")
+    skill_set = tables.ManyToManyColumn(verbose_name="Skills")
 
     class Meta:
         """Meta options for the LearningResourcesTable."""
@@ -45,7 +45,7 @@ class LearningResourcesTable(tables.Table):
         )
 
     def render_skill_set(self, value: "ManyRelatedManager[Skill]") -> SafeString:
-        """Include the related skills as badges."""
+        """Include the relevant skills as badges."""
         return mark_safe(
             "".join(
                 format_html(

--- a/main/tables.py
+++ b/main/tables.py
@@ -16,9 +16,7 @@ if TYPE_CHECKING:  # pragma: no cover
 class LearningResourcesTable(tables.Table):
     """Table class for the LearningResources model."""
 
-    skill_set = tables.ManyToManyColumn(
-        transform=lambda s: s.name, verbose_name="Related Skills"
-    )
+    skill_set = tables.ManyToManyColumn(verbose_name="Related Skills")
 
     class Meta:
         """Meta options for the LearningResourcesTable."""
@@ -30,7 +28,7 @@ class LearningResourcesTable(tables.Table):
     def render_name(self, value: str, record: LearningResource) -> SafeString:
         """Include the URL in the name."""
         return format_html(
-            '<a href="{}" target="_blank" rel="noopener noreferrer">{}<a>',
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
             record.url,
             value,
         )
@@ -41,7 +39,7 @@ class LearningResourcesTable(tables.Table):
             return mark_safe(value)
 
         return format_html(
-            '<a href="{}" target="_blank" rel="noopener noreferrer">{}<a>',
+            '<a href="{}" target="_blank" rel="noopener noreferrer">{}</a>',
             record.provider.url,
             value,
         )
@@ -52,7 +50,7 @@ class LearningResourcesTable(tables.Table):
             "".join(
                 format_html(
                     '<a href="{}" target="_blank" rel="noopener noreferrer" '
-                    'class="badge bg-secondary">{}<a>',
+                    'class="badge bg-secondary">{}</a>',
                     reverse("skill_detail", args=(skill.slug,)),
                     skill.name,
                 )

--- a/main/templates/main/pages/framework-overview.html
+++ b/main/templates/main/pages/framework-overview.html
@@ -31,21 +31,6 @@
                    href="{% url 'skills_and_competencies' %}">Browse framework</a>
                 {% include "main/snippets/framework-mermaid-diagram.html" %}
             </div>
-            <aside class="col-lg-3 offset-xl-1">
-                <div class="offcanvas-lg offcanvas-end" id="sidebar">
-                    <div class="offcanvas-header">
-                        <h4 class="offcanvas-title">Sidebar</h4>
-                        <button class="btn-close ms-auto"
-                                type="button"
-                                data-bs-dismiss="offcanvas"
-                                data-bs-target="#sidebar"
-                                aria-label="Close"></button>
-                    </div>
-                    <div class="offcanvas-body">
-                        <h4 class="pt-1 pt-lg-0 mt-lg-n2"></h4>
-                    </div>
-                </div>
-            </aside>
         </div>
     </section>
 {% endblock content %}

--- a/main/templates/main/pages/learning-resources.html
+++ b/main/templates/main/pages/learning-resources.html
@@ -11,7 +11,7 @@
     <li class="breadcrumb-item active" aria-current="page">Learning resources</li>
 {% endblock breadcrumb_items %}
 {% block content %}
-    <section id="training">
+    <section id="learning-resources">
         <div class="row">
             <div class="col pe-lg-4 pe-xl-0">
                 <h1 class="pb-2 pb-lg-3">Learning resources</h1>

--- a/main/templates/main/pages/learning-resources.html
+++ b/main/templates/main/pages/learning-resources.html
@@ -1,5 +1,6 @@
 {% extends "main/base.page.html" %}
 {% load static %}
+{% load render_table from django_tables2 %}
 {% block title %}
     Digital Research Competencies Framework
 {% endblock title %}
@@ -12,11 +13,9 @@
 {% block content %}
     <section id="training">
         <div class="row">
-            <div class="col-lg-9 col-xl-8 pe-lg-4 pe-xl-0">
+            <div class="col pe-lg-4 pe-xl-0">
                 <h1 class="pb-2 pb-lg-3">Learning resources</h1>
-                <p class="fs-lg mb-5">
-                    This section will be developed in future to provide resources for training and personal development pathways.
-                </p>
+                {% render_table table %}
             </div>
             <aside class="col-lg-3 offset-xl-1">
                 <div class="offcanvas-lg offcanvas-end" id="sidebar">

--- a/main/templates/main/pages/learning-resources.html
+++ b/main/templates/main/pages/learning-resources.html
@@ -17,21 +17,6 @@
                 <h1 class="pb-2 pb-lg-3">Learning resources</h1>
                 {% render_table table %}
             </div>
-            <aside class="col-lg-3 offset-xl-1">
-                <div class="offcanvas-lg offcanvas-end" id="sidebar">
-                    <div class="offcanvas-header">
-                        <h4 class="offcanvas-title">Sidebar</h4>
-                        <button class="btn-close ms-auto"
-                                type="button"
-                                data-bs-dismiss="offcanvas"
-                                data-bs-target="#sidebar"
-                                aria-label="Close"></button>
-                    </div>
-                    <div class="offcanvas-body">
-                        <h4 class="pt-1 pt-lg-0 mt-lg-n2"></h4>
-                    </div>
-                </div>
-            </aside>
         </div>
     </section>
 {% endblock content %}

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -11,8 +11,16 @@ from typing import Any
 from django.shortcuts import get_object_or_404
 from django.templatetags.static import static
 from django.views.generic.base import TemplateView
+from django_tables2 import SingleTableView
 
-from ..models import CompetencyDomain, Skill, SkillLevel, ToolLanguageMethodology
+from ..models import (
+    CompetencyDomain,
+    LearningResource,
+    Skill,
+    SkillLevel,
+    ToolLanguageMethodology,
+)
+from ..tables import LearningResourcesTable
 
 logger = logging.getLogger(__name__)
 
@@ -85,9 +93,11 @@ class SkillLevelsPageView(TemplateView):
         return context
 
 
-class LearningResourcesPageView(TemplateView):
+class LearningResourcesPageView(SingleTableView):
     """View that renders the page with all learning resources."""
 
+    model = LearningResource
+    table_class = LearningResourcesTable
     template_name = "main/pages/learning-resources.html"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "whitenoise",
     "mysqlclient",
     "django-import-export",
-    "django-multiselectfield"
+    "django-multiselectfield",
+    "django-tables2"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,10 @@ module = ["django_registration.*"]
 follow_untyped_imports = true
 
 [[tool.mypy.overrides]]
+module = ["django_tables2.*"]
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
 module = ["main.io_resources"]
 disallow_any_generics = false
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ django==6.0.3
     #   django-multiselectfield
     #   django-registration
     #   django-stubs-ext
+    #   django-tables2
 django-bootstrap5==26.2
     # via direct_webapp (pyproject.toml)
 django-crispy-forms==2.6
@@ -35,6 +36,8 @@ django-multiselectfield==1.0.1
 django-registration==5.2.1
     # via direct_webapp (pyproject.toml)
 django-stubs-ext==6.0.2
+    # via direct_webapp (pyproject.toml)
+django-tables2==3.0.0
     # via direct_webapp (pyproject.toml)
 gunicorn==25.3.0
     # via direct_webapp (pyproject.toml)

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -396,13 +396,38 @@ class TestSkillLevelsPageView(TemplateOkMixin):
         return reverse("skill_levels")
 
 
-class TestLearningResourcesPageView(TemplateOkMixin):
+class TestLearningResourcesPageView(TemplateOkMixin, BS4Mixin):
     """Test suite for the LearningResourcesPageView."""
 
     _template_name = "main/pages/learning-resources.html"
 
     def _get_url(self):
         return reverse("learning_resources")
+
+    @pytest.mark.django_db
+    def test_page_content(self, learning_resource, skill, soup):
+        """Test that the learning page contains a table with learning resources."""
+        assert "Learning resources" == soup.find("h1").text
+
+        table = soup.find("table")
+        thead = table.find("thead")
+        assert thead.find(tag_with_text_filter("th", "Name"), class_="asc orderable")
+        assert thead.find(tag_with_text_filter("th", "Language"), class_="orderable")
+        assert thead.find(tag_with_text_filter("th", "Provider"), class_="orderable")
+        assert thead.find(tag_with_text_filter("th", "Related Skills"))
+        tr = table.find("tbody").find("tr", class_="even")
+        assert tr.find(
+            tag_with_text_filter("a", "Learning Resource"), href=learning_resource.url
+        )
+        assert tr.find(tag_with_text_filter("td", "English"))
+        assert tr.find(
+            tag_with_text_filter("a", "Provider"), href=learning_resource.provider.url
+        )
+        assert tr.find(
+            tag_with_text_filter("a", "Skill"),
+            class_="badge",
+            href=reverse("skill_detail", args=(skill.slug,)),
+        )
 
 
 class TestGetInvolvedPageView(TemplateOkMixin):

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -414,7 +414,7 @@ class TestLearningResourcesPageView(TemplateOkMixin, BS4Mixin):
         assert thead.find(tag_with_text_filter("th", "Name"), class_="asc orderable")
         assert thead.find(tag_with_text_filter("th", "Language"), class_="orderable")
         assert thead.find(tag_with_text_filter("th", "Provider"), class_="orderable")
-        assert thead.find(tag_with_text_filter("th", "Related Skills"))
+        assert thead.find(tag_with_text_filter("th", "Skills"))
         tr = table.find("tbody").find("tr", class_="even")
         assert tr.find(
             tag_with_text_filter("a", "Learning Resource"), href=learning_resource.url

--- a/tests/main/test_tables.py
+++ b/tests/main/test_tables.py
@@ -1,0 +1,63 @@
+"""Tests for the tables classes in the main app."""
+
+import pytest
+from django.urls import reverse
+
+from main.models import LearningResource, Provider, Skill
+from main.tables import LearningResourcesTable
+
+
+@pytest.mark.django_db
+def test_learning_resources_table_render_name(learning_resource: LearningResource):
+    """Test the learning resource name renders as an external link."""
+    table = LearningResourcesTable([])
+
+    rendered = table.render_name(learning_resource.name, learning_resource)
+
+    assert str(rendered) == (
+        f'<a href="{learning_resource.url}" target="_blank" '
+        'rel="noopener noreferrer">Learning Resource</a>'
+    )
+
+
+@pytest.mark.django_db
+def test_learning_resources_table_render_provider(learning_resource: LearningResource):
+    """Test the provider name renders as an external link when a URL exists."""
+    table = LearningResourcesTable([])
+
+    assert isinstance(learning_resource.provider, Provider)
+
+    rendered = table.render_provider(learning_resource.provider.name, learning_resource)
+
+    assert str(rendered) == (
+        f'<a href="{learning_resource.provider.url}" target="_blank" '
+        'rel="noopener noreferrer">Provider</a>'
+    )
+
+
+@pytest.mark.django_db
+def test_learning_resources_table_render_provider_without_url(
+    learning_resource: LearningResource,
+):
+    """Test the provider name renders as plain text when no URL exists."""
+    table = LearningResourcesTable([])
+    learning_resource.provider = None
+
+    rendered = table.render_provider("Provider", learning_resource)
+
+    assert str(rendered) == "Provider"
+
+
+@pytest.mark.django_db
+def test_learning_resources_table_render_skill_set(
+    learning_resource: LearningResource, skill: Skill
+):
+    """Test related skills render as badge links."""
+    table = LearningResourcesTable([])
+
+    rendered = table.render_skill_set(learning_resource.skill_set)  # type: ignore[arg-type]
+
+    assert str(rendered) == (
+        '<a href="{}" target="_blank" rel="noopener noreferrer" '
+        'class="badge bg-secondary">Skill</a>'
+    ).format(reverse("skill_detail", args=(skill.slug,)))


### PR DESCRIPTION
# Description

This PR adds a table of learning resources to the learning resources page. It looks like this

<img width="1482" height="964" alt="Screenshot 2026-04-15 at 17 27 31" src="https://github.com/user-attachments/assets/b277119e-7a99-4519-a6f1-70b873594900" />

Fixes #670

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
