### PR TITLE
Add governance and licensing pages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,8 @@ repos:
         additional_dependencies:
           - django-stubs[compatible-mypy]
           - django-stubs-ext
+          - types-Markdown
+          - types-requests
           - django-bootstrap5
           - django-registration
           - django-crispy-forms

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,8 +10,12 @@ beautifulsoup4==4.14.3
     # via direct_webapp (pyproject.toml)
 build==1.4.2
     # via pip-tools
+certifi==2026.4.22
+    # via requests
 cfgv==3.5.0
     # via pre-commit
+charset-normalizer==3.4.7
+    # via requests
 click==8.3.1
     # via
     #   djlint
@@ -78,6 +82,8 @@ gunicorn==25.3.0
     # via direct_webapp (pyproject.toml)
 identify==2.6.18
     # via pre-commit
+idna==3.13
+    # via requests
 iniconfig==2.3.0
     # via pytest
 jsbeautifier==1.15.4
@@ -88,6 +94,8 @@ json5==0.14.0
     # via djlint
 librt==0.8.1
     # via mypy
+markdown==3.10.2
+    # via direct_webapp (pyproject.toml)
 mypy==1.20.0
     # via
     #   direct_webapp (pyproject.toml)
@@ -146,6 +154,8 @@ pyyaml==6.0.3
     #   pre-commit
 regex==2026.3.32
     # via djlint
+requests==2.33.1
+    # via direct_webapp (pyproject.toml)
 ruff==0.15.8
     # via direct_webapp (pyproject.toml)
 six==1.17.0
@@ -162,14 +172,22 @@ tqdm==4.67.3
     # via djlint
 types-django-import-export==4.4.0.20260325
     # via direct_webapp (pyproject.toml)
+types-markdown==3.10.2.20260408
+    # via direct_webapp (pyproject.toml)
 types-pyyaml==6.0.12.20250915
     # via django-stubs
+types-requests==2.33.0.20260408
+    # via direct_webapp (pyproject.toml)
 typing-extensions==4.15.0
     # via
     #   beautifulsoup4
     #   django-stubs
     #   django-stubs-ext
     #   mypy
+urllib3==2.6.3
+    # via
+    #   requests
+    #   types-requests
 virtualenv==21.2.0
     # via pre-commit
 wheel==0.46.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -104,6 +104,8 @@ mypy-extensions==1.1.0
     # via mypy
 mysqlclient==2.2.8
     # via direct_webapp (pyproject.toml)
+nh3==0.3.4
+    # via direct_webapp (pyproject.toml)
 nodeenv==1.10.0
     # via pre-commit
 packaging==26.0

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -71,6 +71,7 @@ jinja2==3.1.6
     #   properdocs
 markdown==3.10.2
     # via
+    #   direct_webapp (pyproject.toml)
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocs-material
@@ -121,6 +122,8 @@ mkdocstrings-python==2.0.3
     # via direct_webapp (pyproject.toml)
 mysqlclient==2.2.8
     # via direct_webapp (pyproject.toml)
+nh3==0.3.4
+    # via direct_webapp (pyproject.toml)
 packaging==26.0
     # via
     #   gunicorn
@@ -161,7 +164,9 @@ pyyaml-env-tag==1.1
     #   mkdocs
     #   properdocs
 requests==2.33.1
-    # via mkdocs-material
+    # via
+    #   direct_webapp (pyproject.toml)
+    #   mkdocs-material
 six==1.17.0
     # via python-dateutil
 sqlparse==0.5.5

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -10,9 +10,9 @@ babel==2.18.0
     # via mkdocs-material
 backrefs==6.2
     # via mkdocs-material
-certifi==2026.2.25
+certifi==2026.4.22
     # via requests
-charset-normalizer==3.4.6
+charset-normalizer==3.4.7
     # via requests
 click==8.3.1
     # via
@@ -61,7 +61,7 @@ griffelib==2.0.2
     # via mkdocstrings-python
 gunicorn==25.3.0
     # via direct_webapp (pyproject.toml)
-idna==3.11
+idna==3.13
     # via requests
 jinja2==3.1.6
     # via

--- a/main/templates/main/pages/policies/governance.html
+++ b/main/templates/main/pages/policies/governance.html
@@ -4,7 +4,7 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item">Policies</li>
     <li class="breadcrumb-item active" aria-current="page">Governance</li>
 {% endblock breadcrumb_items %}
 {% block content %}

--- a/main/templates/main/pages/policies/governance.html
+++ b/main/templates/main/pages/policies/governance.html
@@ -11,7 +11,7 @@
     <section id="licensing" class="container">
         <h1 class="display-4 text-center pb-2 pb-lg-3">{{ page_heading }}</h1>
         <div class="row justify-content-center pt-xxl-2">
-            <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
+            <div class="col-lg-9 col-xl-8">{{ markdown_content }}</div>
         </div>
     </section>
 {% endblock content %}

--- a/main/templates/main/pages/policies/governance.html
+++ b/main/templates/main/pages/policies/governance.html
@@ -1,0 +1,19 @@
+{% extends "main/base.page.html" %}
+{% load static %}
+{% block title %}
+    Digital Research Competencies Framework
+{% endblock title %}
+{% block breadcrumb_items %}
+    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item active" aria-current="page">Governance</li>
+{% endblock breadcrumb_items %}
+{% block content %}
+    <section id="governance" class="pt-5 text-center ">
+        <h1 class="display-4 pb-2 pb-lg-3">{{ page_heading }}</h1>
+    </section>
+    <section class="container pt-5 mt-md-2 mt-lg-3 mt-xl-4">
+        <div class="row justify-content-center pt-xxl-2">
+            <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
+        </div>
+    </section>
+{% endblock content %}

--- a/main/templates/main/pages/policies/governance.html
+++ b/main/templates/main/pages/policies/governance.html
@@ -8,10 +8,8 @@
     <li class="breadcrumb-item active" aria-current="page">Governance</li>
 {% endblock breadcrumb_items %}
 {% block content %}
-    <section id="governance" class="pt-5 text-center ">
-        <h1 class="display-4 pb-2 pb-lg-3">{{ page_heading }}</h1>
-    </section>
-    <section class="container pt-5 mt-md-2 mt-lg-3 mt-xl-4">
+    <section id="licensing" class="container">
+        <h1 class="display-4 text-center pb-2 pb-lg-3">{{ page_heading }}</h1>
         <div class="row justify-content-center pt-xxl-2">
             <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
         </div>

--- a/main/templates/main/pages/policies/licensing.html
+++ b/main/templates/main/pages/policies/licensing.html
@@ -4,14 +4,12 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item">Policies</li>
     <li class="breadcrumb-item active" aria-current="page">Licensing</li>
 {% endblock breadcrumb_items %}
 {% block content %}
-    <section id="licensing" class="pt-5 text-center ">
-        <h1 class="display-4 pb-2 pb-lg-3">{{ page_heading }}</h1>
-    </section>
-    <section class="container pt-5 mt-md-2 mt-lg-3 mt-xl-4">
+    <section id="licensing" class="container">
+        <h1 class="display-4 text-center pb-2 pb-lg-3">{{ page_heading }}</h1>
         <div class="row justify-content-center pt-xxl-2">
             <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
         </div>

--- a/main/templates/main/pages/policies/licensing.html
+++ b/main/templates/main/pages/policies/licensing.html
@@ -1,0 +1,19 @@
+{% extends "main/base.page.html" %}
+{% load static %}
+{% block title %}
+    Digital Research Competencies Framework
+{% endblock title %}
+{% block breadcrumb_items %}
+    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item active" aria-current="page">Licensing</li>
+{% endblock breadcrumb_items %}
+{% block content %}
+    <section id="licensing" class="pt-5 text-center ">
+        <h1 class="display-4 pb-2 pb-lg-3">{{ page_heading }}</h1>
+    </section>
+    <section class="container pt-5 mt-md-2 mt-lg-3 mt-xl-4">
+        <div class="row justify-content-center pt-xxl-2">
+            <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
+        </div>
+    </section>
+{% endblock content %}

--- a/main/templates/main/pages/policies/licensing.html
+++ b/main/templates/main/pages/policies/licensing.html
@@ -11,7 +11,7 @@
     <section id="licensing" class="container">
         <h1 class="display-4 text-center pb-2 pb-lg-3">{{ page_heading }}</h1>
         <div class="row justify-content-center pt-xxl-2">
-            <div class="col-lg-9 col-xl-8">{{ markdown_content|safe }}</div>
+            <div class="col-lg-9 col-xl-8">{{ markdown_content }}</div>
         </div>
     </section>
 {% endblock content %}

--- a/main/templates/main/pages/policies/privacy.html
+++ b/main/templates/main/pages/policies/privacy.html
@@ -4,7 +4,7 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item">Policies</li>
     <li class="breadcrumb-item active" aria-current="page">Privacy</li>
 {% endblock breadcrumb_items %}
 {% block content %}

--- a/main/templates/main/pages/policies/privacy.html
+++ b/main/templates/main/pages/policies/privacy.html
@@ -4,7 +4,8 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item active" aria-current="page">Privacy Policy</li>
+    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item active" aria-current="page">Privacy</li>
 {% endblock breadcrumb_items %}
 {% block content %}
     <section id="privacy" class="container">

--- a/main/templates/main/pages/policies/terms.html
+++ b/main/templates/main/pages/policies/terms.html
@@ -4,14 +4,12 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
-    <li class="breadcrumb-item" aria-current="page">Policies</li>
+    <li class="breadcrumb-item">Policies</li>
     <li class="breadcrumb-item active" aria-current="page">Terms and Conditions</li>
 {% endblock breadcrumb_items %}
 {% block content %}
-    <section id="terms">
+    <section id="terms" class="container">
         <h1 class="display-4 text-center pb-2 pb-lg-3">Terms and Conditions</h1>
-    </section>
-    <section class="container pt-5 mt-md-2 mt-lg-3 mt-xl-4">
         <div class="row justify-content-center pt-xxl-2">
             <div class="col-lg-9 col-xl-8">
                 <p class="fs-lg">

--- a/main/templates/main/pages/policies/terms.html
+++ b/main/templates/main/pages/policies/terms.html
@@ -4,6 +4,7 @@
     Digital Research Competencies Framework
 {% endblock title %}
 {% block breadcrumb_items %}
+    <li class="breadcrumb-item" aria-current="page">Policies</li>
     <li class="breadcrumb-item active" aria-current="page">Terms and Conditions</li>
 {% endblock breadcrumb_items %}
 {% block content %}

--- a/main/templates/main/snippets/footer.html
+++ b/main/templates/main/snippets/footer.html
@@ -90,6 +90,9 @@
                             <h6 class="text-muted text-uppercase fs-xs fw-semibold mb-3">Framework</h6>
                             <ul class="nav flex-column mb-0">
                                 <li class="nav-item mb-2">
+                                    <a class="nav-link p-0" href="{% url 'framework_overview' %}">Overview</a>
+                                </li>
+                                <li class="nav-item mb-2">
                                     <a class="nav-link p-0" href="{% url 'skills_and_competencies' %}">Competencies framework</a>
                                 </li>
                                 <li class="nav-item mb-2">

--- a/main/templates/main/snippets/footer.html
+++ b/main/templates/main/snippets/footer.html
@@ -90,13 +90,13 @@
                             <h6 class="text-muted text-uppercase fs-xs fw-semibold mb-3">Framework</h6>
                             <ul class="nav flex-column mb-0">
                                 <li class="nav-item mb-2">
-                                    <a class="nav-link p-0" href="{% url 'competencies' %}">Competencies framework</a>
+                                    <a class="nav-link p-0" href="{% url 'skills_and_competencies' %}">Competencies framework</a>
                                 </li>
                                 <li class="nav-item mb-2">
                                     <a class="nav-link p-0" href="{% url 'skill_levels' %}">Skill levels</a>
                                 </li>
                                 <li class="nav-item mb-2">
-                                    <a class="nav-link p-0" href="{% url 'training' %}">Learning resources</a>
+                                    <a class="nav-link p-0" href="{% url 'learning_resources' %}">Learning resources</a>
                                 </li>
                                 <li class="nav-item mb-2">
                                     <a class="nav-link p-0" href="{% url 'roles' %}">Roles and career pathways</a>
@@ -107,10 +107,10 @@
                             <h6 class="text-muted text-uppercase fs-xs fw-semibold mb-3">Policies</h6>
                             <ul class="nav flex-column mb-0">
                                 <li class="nav-item mb-2">
-                                    <a class="nav-link p-0" href="">Licensing</a>
+                                    <a class="nav-link p-0" href="{% url 'licensing' %}">Licensing</a>
                                 </li>
                                 <li class="nav-item mb-2">
-                                    <a class="nav-link p-0" href="">Goverenance</a>
+                                    <a class="nav-link p-0" href="{% url 'governance' %}">Goverenance</a>
                                 </li>
                                 <li class="nav-item mb-2">
                                     <a class="nav-link p-0" href="{% url 'privacy' %}">Privacy policy</a>

--- a/main/templates/main/snippets/footer.html
+++ b/main/templates/main/snippets/footer.html
@@ -113,7 +113,7 @@
                                     <a class="nav-link p-0" href="{% url 'licensing' %}">Licensing</a>
                                 </li>
                                 <li class="nav-item mb-2">
-                                    <a class="nav-link p-0" href="{% url 'governance' %}">Goverenance</a>
+                                    <a class="nav-link p-0" href="{% url 'governance' %}">Governance</a>
                                 </li>
                                 <li class="nav-item mb-2">
                                     <a class="nav-link p-0" href="{% url 'privacy' %}">Privacy policy</a>

--- a/main/templates/main/snippets/navbar.html
+++ b/main/templates/main/snippets/navbar.html
@@ -115,7 +115,7 @@
                                 <a class="dropdown-item" href="{% url 'learning_resources' %}">Learning resources</a>
                             </li>
                             <li>
-                                <a class="dropdown-item" href="{% url 'roles' %}">Roles and job profiles</a>
+                                <a class="dropdown-item" href="{% url 'roles' %}">Roles & career pathways</a>
                             </li>
                         </ul>
                     </li>

--- a/main/urls.py
+++ b/main/urls.py
@@ -33,9 +33,15 @@ accounts_patterns = [
     path("overview/", views.AccountOverviewView.as_view(), name="account-overview"),
 ]
 
+policies_patterns = [
+    path("privacy/", views.PrivacyPageView.as_view(), name="privacy"),
+    path("terms/", views.TermsPageView.as_view(), name="terms"),
+    path("governance/", views.GovernancePageView.as_view(), name="governance"),
+    path("licensing/", views.LicensingPageView.as_view(), name="licensing"),
+]
+
 urlpatterns = [
     path("", views.IndexPageView.as_view(), name="index"),
-    path("privacy/", views.PrivacyPageView.as_view(), name="privacy"),
     path(
         "accounts/register/",
         RegistrationView.as_view(form_class=RegistrationForm),
@@ -45,16 +51,14 @@ urlpatterns = [
     path("accounts/", include("django.contrib.auth.urls")),
     path("accounts/", include(accounts_patterns)),
     path("about/", views.AboutPageView.as_view(), name="about"),
-    path("terms/", views.TermsPageView.as_view(), name="terms"),
     path(
         "terms-acceptance/",
         views.TermsAcceptanceView.as_view(),
         name="terms_acceptance",
     ),
     path("framework/", include(framework_patterns)),
+    path("policies/", include(policies_patterns)),
     path("get-involved/", views.GetInvolvedPageView.as_view(), name="get_involved"),
     path("events/", views.EventsPageView.as_view(), name="events"),
     path("framework-json/", views.FrameworkView.as_view(), name="framework_json"),
-    path("governance/", views.GovernancePageView.as_view(), name="governance"),
-    path("licensing/", views.LicensingPageView.as_view(), name="licensing"),
 ]

--- a/main/urls.py
+++ b/main/urls.py
@@ -55,4 +55,6 @@ urlpatterns = [
     path("get-involved/", views.GetInvolvedPageView.as_view(), name="get_involved"),
     path("events/", views.EventsPageView.as_view(), name="events"),
     path("framework-json/", views.FrameworkView.as_view(), name="framework_json"),
+    path("governance/", views.GovernancePageView.as_view(), name="governance"),
+    path("licensing/", views.LicensingPageView.as_view(), name="licensing"),
 ]

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -235,6 +235,23 @@ class GitHubMarkdownPageView(TemplateView):
     unavailable_message = "Document is temporarily unavailable."
     markdown_extensions: ClassVar[list[str]] = ["fenced_code", "tables", "toc"]
 
+    def _strip_duplicate_heading(self, markdown_text: str) -> str:
+        """Remove leading H1 if it duplicates the configured page heading."""
+        lines = markdown_text.splitlines()
+        if not lines:
+            return markdown_text
+
+        first_line = lines[0].strip()
+        if self.page_heading not in first_line:
+            return markdown_text
+
+        # Remove the duplicate title line and one following blank line if present.
+        del lines[0]
+        if lines and lines[0].strip() == "":
+            del lines[0]
+
+        return "\n".join(lines)
+
     def get_markdown_content(self) -> str:
         """Fetch and convert remote markdown content to HTML."""
         if not self.github_raw_url:
@@ -242,8 +259,9 @@ class GitHubMarkdownPageView(TemplateView):
 
         response = requests.get(self.github_raw_url, timeout=5)
         response.raise_for_status()
+        markdown_text = self._strip_duplicate_heading(response.text)
         return markdown.markdown(
-            response.text,
+            markdown_text,
             extensions=self.markdown_extensions,
         )
 

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -9,10 +9,13 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import markdown
+import nh3
 import requests
 from django.shortcuts import get_object_or_404
 from django.templatetags.static import static
+from django.utils.decorators import method_decorator
 from django.utils.safestring import mark_safe
+from django.views.decorators.cache import cache_page
 from django.views.generic.base import TemplateView
 from django_tables2 import SingleTableView
 
@@ -271,7 +274,9 @@ class GitHubMarkdownPageView(TemplateView):
         context["page_heading"] = self.page_heading
 
         try:
-            context["markdown_content"] = mark_safe(self.get_markdown_content())
+            context["markdown_content"] = mark_safe(
+                nh3.clean(self.get_markdown_content())
+            )
         except requests.RequestException:
             logger.exception("Failed to load markdown from %s", self.github_raw_url)
             context["markdown_content"] = mark_safe(
@@ -281,7 +286,7 @@ class GitHubMarkdownPageView(TemplateView):
         return context
 
 
-# @method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
+@method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
 class GovernancePageView(GitHubMarkdownPageView):
     """View that renders the governance page from GitHub Markdown."""
 
@@ -294,7 +299,7 @@ class GovernancePageView(GitHubMarkdownPageView):
     )
 
 
-# @method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
+@method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
 class LicensingPageView(GitHubMarkdownPageView):
     """View that renders the licensing page from GitHub Markdown."""
 

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -6,10 +6,13 @@ import logging
 from collections.abc import Mapping
 from json import dumps
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
+import markdown
+import requests
 from django.shortcuts import get_object_or_404
 from django.templatetags.static import static
+from django.utils.safestring import mark_safe
 from django.views.generic.base import TemplateView
 from django_tables2 import SingleTableView
 
@@ -65,7 +68,7 @@ class IndexPageView(TemplateView):
 class PrivacyPageView(TemplateView):
     """View that renders the privacy page."""
 
-    template_name = "main/pages/privacy.html"
+    template_name = "main/pages/policies/privacy.html"
 
 
 class AboutPageView(TemplateView):
@@ -77,7 +80,7 @@ class AboutPageView(TemplateView):
 class TermsPageView(TemplateView):
     """View that renders the terms and conditions page."""
 
-    template_name = "main/pages/terms.html"
+    template_name = "main/pages/policies/terms.html"
 
 
 class SkillLevelsPageView(TemplateView):
@@ -222,3 +225,65 @@ class FrameworkOverviewPageView(TemplateView):
     """View that renders an overview page for the framework."""
 
     template_name = "main/pages/framework-overview.html"
+
+
+class GitHubMarkdownPageView(TemplateView):
+    """Base view for pages that render markdown content fetched from GitHub."""
+
+    github_raw_url = ""
+    page_heading = ""
+    unavailable_message = "Document is temporarily unavailable."
+    markdown_extensions: ClassVar[list[str]] = ["fenced_code", "tables", "toc"]
+
+    def get_markdown_content(self) -> str:
+        """Fetch and convert remote markdown content to HTML."""
+        if not self.github_raw_url:
+            raise ValueError("github_raw_url must be set on GitHubMarkdownPageView")
+
+        response = requests.get(self.github_raw_url, timeout=5)
+        response.raise_for_status()
+        return markdown.markdown(
+            response.text,
+            extensions=self.markdown_extensions,
+        )
+
+    def get_context_data(self, **kwargs: Mapping[str, Any]) -> dict[str, Any]:
+        """Add rendered markdown content and page metadata to the context."""
+        context = super().get_context_data(**kwargs)
+        context["page_heading"] = self.page_heading
+
+        try:
+            context["markdown_content"] = mark_safe(self.get_markdown_content())
+        except requests.RequestException:
+            logger.exception("Failed to load markdown from %s", self.github_raw_url)
+            context["markdown_content"] = mark_safe(
+                f"<p>{self.unavailable_message}</p>"
+            )
+
+        return context
+
+
+# @method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
+class GovernancePageView(GitHubMarkdownPageView):
+    """View that renders the governance page from GitHub Markdown."""
+
+    template_name = "main/pages/policies/governance.html"
+    page_heading = "DIRECT Governance"
+    unavailable_message = "Governance document is temporarily unavailable."
+
+    github_raw_url = (
+        "https://raw.githubusercontent.com/direct-framework/.github/main/GOVERNANCE.md"
+    )
+
+
+# @method_decorator(cache_page(60 * 60), name="dispatch")  # cache 1 hour
+class LicensingPageView(GitHubMarkdownPageView):
+    """View that renders the licensing page from GitHub Markdown."""
+
+    template_name = "main/pages/policies/licensing.html"
+    page_heading = "DIRECT Licensing"
+    unavailable_message = "Licensing document is temporarily unavailable."
+
+    github_raw_url = (
+        "https://raw.githubusercontent.com/direct-framework/.github/main/LICENSING.md"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dependencies = [
     "mysqlclient",
     "django-import-export",
     "django-multiselectfield",
-    "django-tables2"
+    "django-tables2",
+    "markdown",
+    "requests"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dev = [
     "django-stubs[compatible-mypy]",
     "djlint",
     "types-django-import-export",
+    "types-Markdown",
+    "types-requests",
     "beautifulsoup4",
 ]
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "django-multiselectfield",
     "django-tables2",
     "markdown",
+    "nh3",
     "requests"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,10 @@
 #
 asgiref==3.11.1
     # via django
+certifi==2026.4.22
+    # via requests
+charset-normalizer==3.4.7
+    # via requests
 confusable-homoglyphs==3.3.1
     # via django-registration
 crispy-bootstrap5==2026.3
@@ -41,15 +45,23 @@ django-tables2==3.0.0
     # via direct_webapp (pyproject.toml)
 gunicorn==25.3.0
     # via direct_webapp (pyproject.toml)
+idna==3.13
+    # via requests
+markdown==3.10.2
+    # via direct_webapp (pyproject.toml)
 mysqlclient==2.2.8
     # via direct_webapp (pyproject.toml)
 packaging==26.0
     # via gunicorn
+requests==2.33.1
+    # via direct_webapp (pyproject.toml)
 sqlparse==0.5.5
     # via django
 tablib==3.9.0
     # via django-import-export
 typing-extensions==4.15.0
     # via django-stubs-ext
+urllib3==2.6.3
+    # via requests
 whitenoise==6.12.0
     # via direct_webapp (pyproject.toml)

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,6 +51,8 @@ markdown==3.10.2
     # via direct_webapp (pyproject.toml)
 mysqlclient==2.2.8
     # via direct_webapp (pyproject.toml)
+nh3==0.3.4
+    # via direct_webapp (pyproject.toml)
 packaging==26.0
     # via gunicorn
 requests==2.33.1

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -149,7 +149,7 @@ class TestIndex(TemplateOkMixin, BS4Mixin):
 class TestPrivacy(TemplateOkMixin):
     """Test suite for the privacy view."""
 
-    _template_name = "main/pages/privacy.html"
+    _template_name = "main/pages/policies/privacy.html"
 
     def _get_url(self):
         return reverse("privacy")
@@ -212,7 +212,7 @@ class TestAboutPageView(TemplateOkMixin, BS4Mixin):
 class TestTermsPageView(TemplateOkMixin):
     """Test suite for the TermsPageView."""
 
-    _template_name = "main/pages/terms.html"
+    _template_name = "main/pages/policies/terms.html"
 
     def _get_url(self):
         return reverse("terms")

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -536,9 +536,27 @@ def test_extract_and_combine_roles():
 
 
 class TestFrameworkOverviewPageView(TemplateOkMixin):
-    """Test suite for the GetInvolvedPageView."""
+    """Test suite for the FrameworkOverviewPageView."""
 
     _template_name = "main/pages/framework-overview.html"
 
     def _get_url(self):
         return reverse("framework_overview")
+
+
+class TestGovernancePageView(TemplateOkMixin):
+    """Test suite for the GovernancePageView."""
+
+    _template_name = "main/pages/policies/governance.html"
+
+    def _get_url(self):
+        return reverse("governance")
+
+
+class TestLicensingPageView(TemplateOkMixin):
+    """Test suite for the LicensingPageView."""
+
+    _template_name = "main/pages/policies/licensing.html"
+
+    def _get_url(self):
+        return reverse("licensing")

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -13,11 +13,7 @@ from django.db.models import QuerySet
 from django.urls import reverse
 from pytest_django.asserts import assertTemplateUsed
 
-from main.models import (
-    Skill,
-    SkillLevel,
-    UserSkill,
-)
+from main.models import Skill, SkillLevel, UserSkill
 from main.views.page_views import _extract_and_combine_roles
 
 from .view_utils import (
@@ -82,7 +78,7 @@ class TestIndex(TemplateOkMixin, BS4Mixin):
             href=reverse("learning_resources"),
         )
         assert framework_dropdown.find(
-            tag_with_text_filter("a", "Roles and job profiles"), href=reverse("roles")
+            tag_with_text_filter("a", "Roles & career pathways"), href=reverse("roles")
         )
 
         # Community Dropdown


### PR DESCRIPTION
# Description

This PR adds a governance and licensing page to the website, where content is pulled directly from Github markdown files. Content should be cached for 1 hour. 

<img width="1504" height="910" alt="image" src="https://github.com/user-attachments/assets/d613ba4a-a0ab-457d-bf52-7659a75f2dae" />

Note: the licensing page on Github doesn't exist yet, and needs to be created. The new page should act as a centralised single point of truth on licensing across the project, and signpost people appropriately to more information as necessary. 

Fixes # (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
