### PR TITLE
Use ghcr address as registry ref in docker build cache-to

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -33,5 +33,7 @@ runs:
         context: .
         push: true
         tags: ${{ steps.meta.outputs.tags }}
-        cache-from: type=gha
-        cache-to: ${{ case(inputs.publish == 'true', format('type=registry,ref={0}', steps.meta.outputs.tags), 'type=gha,mode=max') }}
+        cache-from: |
+          type=gha
+          type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
+        cache-to: ${{ case(inputs.publish == 'true', format('type=registry,ref=ghcr.io/{0}:buildcache,mode=max', github.repository), 'type=gha,mode=max') }}

--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -37,3 +37,4 @@ runs:
           type=gha
           type=registry,ref=ghcr.io/${{ github.repository }}:buildcache
         cache-to: ${{ case(inputs.publish == 'true', format('type=registry,ref=ghcr.io/{0}:buildcache,mode=max', github.repository), 'type=gha,mode=max') }}
+        platforms: linux/amd64

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Test Docker build
+      - name: Publish Docker build
         uses: ./.github/actions/docker-build
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This PR implements the suggested fix by @davehorsfall to fix the bug with deployed images not working. I _think_ this is what you meant, Dave...

Fixes #723

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
