### PR TITLE
Temporary fix for linkspector CI failures

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,6 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+
+      # TODO: Remove this workaround once action-linkspector handles puppeteer's Chrome install on its own.
+      # See: https://github.com/UmbrellaDocs/action-linkspector/issues/62
+      - name: Install Chrome for puppeteer
+        shell: bash
+        run: npx --yes puppeteer@^24 browsers install chrome
+
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
# Description

This uses the solution in https://github.com/coder/coder/pull/25859 to fix the errors causing linkspector to fail. Hopefully it is only temporary. It seems like the latest version of "puppeteer" is not correctly pointing to chrome, which is required by linkspector to work.

We need this merged before anything else because this link check is failing on every PR, preventing them from being merged.

Fixes #729 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
