### PR TITLE
Add an export button to the user skills profile

### DIFF
--- a/main/templates/main/snippets/export_user_skill_profile.html
+++ b/main/templates/main/snippets/export_user_skill_profile.html
@@ -1,0 +1,33 @@
+<!-- This template implements a export button to export the current user's skill profile as a CSV file.
+ It works on the skill profile page.
+
+
+To use add a button with the class "export-skill-profile" to the page and include the following script at the end of the page.
+"{ % include "main/snippets/export_user_skill_profile.html" %}"
+
+-->
+<script>
+    const exportSkillProfileButton = document.querySelector('.export-skill-profile');
+    exportSkillProfileButton.addEventListener('click', function () {
+      // The skill levels and chart data are passed from the Django view
+      // We assume we receive the same data as the skill wheel.
+      const skillLevels = {{ skill_levels|safe }};
+      const charts = {{ chart_data|safe }};
+
+      const csvRows = [];
+      csvRows.push(['Category', 'Subcategory', 'Skill', 'Level'].join(','));
+      charts.forEach(({user_data, user_id}) => {
+        user_data.forEach(({category, skill, skill_level, subcategory}) => {
+          csvRows.push([`"${category}"`, `"${subcategory}"`, `"${skill}"`, skill_level].join(','));
+        });
+      });
+      const csvContent = "data:text/csv;charset=utf-8," + csvRows.join('\n');
+      const encodedUri = encodeURI(csvContent);
+      const link = document.createElement("a");
+      link.setAttribute("href", encodedUri);
+      link.setAttribute("download", "skill_profile.csv");
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+    });
+</script>

--- a/main/templates/main/snippets/export_user_skill_profile.html
+++ b/main/templates/main/snippets/export_user_skill_profile.html
@@ -1,4 +1,4 @@
-<!-- This template implements a export button to export the current user's skill profile as a CSV file.
+<!-- This template implements an export button to export the current user's skill profile as a CSV file.
  It works on the skill profile page.
 
 
@@ -15,7 +15,7 @@ To use add a button with the class "export-skill-profile" to the page and includ
       const charts = {{ chart_data|safe }};
 
       const csvRows = [];
-      csvRows.push(['Category', 'Subcategory', 'Skill', 'Level'].join(','));
+      csvRows.push(['Competency Domain', 'Competency', 'Skill', 'Level'].join(','));
       charts.forEach(({user_data, user_id}) => {
         user_data.forEach(({category, skill, skill_level, subcategory}) => {
           csvRows.push([`"${category}"`, `"${subcategory}"`, `"${skill}"`, skill_level].join(','));

--- a/main/templates/main/user-skills-profile.html
+++ b/main/templates/main/user-skills-profile.html
@@ -32,6 +32,8 @@
                         </p>
                         <div id="dataviz_root" style="width:100%"></div>
                         {% include "main/snippets/skill-wheel.html" %}
+                        <button class="export-skill-profile btn btn-primary mt-4">Export as CSV</button>
+                        {% include "main/snippets/export_user_skill_profile.html" %}
                     </div>
                 </section>
             </div>


### PR DESCRIPTION
- Part of #742

# Description

Implementation of a download your profile button.

Clicking the `export as csv` button will export the profile as a csv.

Screenshot: 
<img width="659" height="727" alt="image" src="https://github.com/user-attachments/assets/c81ef319-a084-4c96-be6f-2ecc467b46c5" />


CSV out:
<img width="704" height="310" alt="image" src="https://github.com/user-attachments/assets/b6ad680c-e4f5-4a5e-8bed-ee3a7f3ee3ca" />


This works entirely in javascript and relies on the data that is supplied to the skill wheel. We might want to revise this when we update the data views.


Part of #742

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
