### PR TITLE
Revert temporary linkspector fix

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,13 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
-      # TODO: Remove this workaround once action-linkspector handles puppeteer's Chrome install on its own.
-      # See: https://github.com/UmbrellaDocs/action-linkspector/issues/62
-      - name: Install Chrome for puppeteer
-        shell: bash
-        run: npx --yes puppeteer@^24 browsers install chrome
-
       - name: Run linkspector
         uses: umbrelladocs/action-linkspector@v1
         with:


### PR DESCRIPTION
# Description

Reverting the temporary fix to make linkspector pass (implemented in #730). Action has been updated and seems to work now.

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
