### PR TITLE
Implement a shareable url of a skills profile that can be viewed when not logged in

### DIFF
--- a/main/templates/main/shared-skills-profile.html
+++ b/main/templates/main/shared-skills-profile.html
@@ -30,6 +30,11 @@
                                 with size according to the self-assessed level.
                             </p>
                             <div id="dataviz_root" style="width:100%"></div>
+                            {% if error_message %}
+                                <div class="alert alert-danger" role="alert">{{ error_message }}</div>
+                            {% else %}
+                                {% include "main/snippets/skill-wheel.html" %}
+                            {% endif %}
                             {% include "main/snippets/skill-wheel.html" %}
                         </div>
                     </section>

--- a/main/templates/main/shared-skills-profile.html
+++ b/main/templates/main/shared-skills-profile.html
@@ -35,7 +35,6 @@
                             {% else %}
                                 {% include "main/snippets/skill-wheel.html" %}
                             {% endif %}
-                            {% include "main/snippets/skill-wheel.html" %}
                         </div>
                     </section>
                 </div>

--- a/main/templates/main/shared-skills-profile.html
+++ b/main/templates/main/shared-skills-profile.html
@@ -5,12 +5,6 @@
 {% load static %}
 {% load crispy_forms_tags %}
 {% load django_bootstrap5 %}
-{% block breadcrumb_items %}
-    <li class="breadcrumb-item">
-        <a href="{% url 'profile' %}">Profile</a>
-    </li>
-    <li class="breadcrumb-item active" aria-current="page">Skills profile</li>
-{% endblock breadcrumb_items %}
 {% block title %}
     Digital Research Competencies Framework
 {% endblock title %}
@@ -18,17 +12,15 @@
     <!-- Page container -->
     <section id="skill-profile" class="container">
         <div class="row pt-sm-2 pt-lg-0">
-            <!-- Sidebar (offcanvas on screens < 992px) -->
-            {% include "main/snippets/profile-sidebar.html" %}
             <!-- Page content -->
             <div class="col-lg-9 pb-2 pb-sm-4">
                 <section class="card border-0 mb-4">
                     <div class="card-body">
-                        <h1>Skills profile</h1>
+                        <h1>Shared Skills profile</h1>
                         <p class="lead">
-                            Explore your skill levels in the Digital Research Competencies Framework
+                            Explore a shared skill level profile in the Digital Research Competencies Framework
                             using the interactive Skills Wheel. Each segment represents a competency,
-                            with size according to your self-assessed level.
+                            with size according to the self-assessed level.
                         </p>
                         <div id="dataviz_root" style="width:100%"></div>
                         {% include "main/snippets/skill-wheel.html" %}
@@ -41,12 +33,4 @@
             </div>
         </div>
     </section>
-    <!-- Sidebar toggle button -->
-    <button class="d-lg-none btn btn-sm fs-sm btn-primary w-100 rounded-0 fixed-bottom"
-            type="button"
-            data-bs-toggle="offcanvas"
-            data-bs-target="#sidebarAccount">
-        <i class="ai-menu me-2"></i>
-        Account menu
-    </button>
 {% endblock content %}

--- a/main/templates/main/shared-skills-profile.html
+++ b/main/templates/main/shared-skills-profile.html
@@ -16,20 +16,24 @@
             <div class="col-lg-9 pb-2 pb-sm-4">
                 <section class="card border-0 mb-4">
                     <div class="card-body">
-                        <h1>Shared Skills profile</h1>
-                        <p class="lead">
-                            Explore a shared skill level profile in the Digital Research Competencies Framework
-                            using the interactive Skills Wheel. Each segment represents a competency,
-                            with size according to the self-assessed level.
-                        </p>
-                        <div id="dataviz_root" style="width:100%"></div>
-                        {% include "main/snippets/skill-wheel.html" %}
-                        <button class="export-skill-profile btn btn-primary mt-4">Export as CSV</button>
-                        {% include "main/snippets/export_user_skill_profile.html" %}
-                        <button class="export-skill-profile-link btn btn-secondary mt-4">Generate shareable link</button>
-                        {% include "main/snippets/create_user_skill_profile_link.html" %}
-                    </div>
-                </section>
+                        <div class="row">
+                            <div class="col-8">
+                                <h1>Shared Skills profile</h1>
+                            </div>
+                            <div class="col-4 text-md-end justify-content-end">
+                                <!-- Share dropdown -->
+                                {% include "main/snippets/share_skill_profile_dropdown.html" %}
+                            </div>
+                            <p class="lead">
+                                Explore a shared skill level profile in the Digital Research Competencies Framework
+                                using the interactive Skills Wheel. Each segment represents a competency,
+                                with size according to the self-assessed level.
+                            </p>
+                            <div id="dataviz_root" style="width:100%"></div>
+                            {% include "main/snippets/skill-wheel.html" %}
+                        </div>
+                    </section>
+                </div>
             </div>
         </div>
     </section>

--- a/main/templates/main/snippets/create_user_skill_profile_link.html
+++ b/main/templates/main/snippets/create_user_skill_profile_link.html
@@ -12,6 +12,7 @@ To use add a button with the class "export-skill-profile-link" to the page and i
   // On document load we convert the skill levels and chart data into a query string and set it as the href of the export link.
   document.addEventListener('DOMContentLoaded', function () {
     const exportSkillProfileLink = document.querySelector('.export-skill-profile-link');
+    const exportSkillProfileLinkCopyButton = document.querySelector('.export-skill-profile-link-copy');
     const skillLevels = {{ skill_levels|safe }};
     const charts = {{ chart_data|safe }};
 
@@ -21,10 +22,10 @@ To use add a button with the class "export-skill-profile-link" to the page and i
     queryParams.set('skill_levels', JSON.stringify(skillLevels));
     queryParams.set('chart_data', JSON.stringify(charts));
 
-    exportSkillProfileLink.href = `${window.location.origin}/view_skill_profile?${queryParams.toString()}`;
     const shareableLink = `${window.location.origin}/view_skill_profile?${queryParams.toString()}`;
-    // exportSkillProfileLink.textContent = `Shareable Link: ${shareableLink}`;
-    exportSkillProfileLink.addEventListener('click', function (event) {
+    exportSkillProfileLink.href = shareableLink;
+    exportSkillProfileLinkCopyButton.href = shareableLink;
+    exportSkillProfileLinkCopyButton.addEventListener('click', function (event) {
       event.preventDefault();
       navigator.clipboard.writeText(shareableLink).then(function() {
         alert('Shareable link copied to clipboard!');

--- a/main/templates/main/snippets/create_user_skill_profile_link.html
+++ b/main/templates/main/snippets/create_user_skill_profile_link.html
@@ -1,0 +1,36 @@
+<!-- This template implements a share user profile link
+ It works by storing the users skill profile in the url query parameters which can then be
+ viewed in a read only non logged in view. This allows users to share their skill profile
+ with others without requiring them to log in or create an account.
+
+
+To use add a button with the class "export-skill-profile-link" to the page and include the following script at the end of the page.
+"{ % include "main/snippets/create_user_skill_profile_link.html" %}"
+
+-->
+<script>
+  // On document load we convert the skill levels and chart data into a query string and set it as the href of the export link.
+  document.addEventListener('DOMContentLoaded', function () {
+    const exportSkillProfileLink = document.querySelector('.export-skill-profile-link');
+    const skillLevels = {{ skill_levels|safe }};
+    const charts = {{ chart_data|safe }};
+
+    const queryParams = new URLSearchParams();
+    // We probably don't need to add skill levels to the query params as they can be derived from the chart data,
+    // but we include them for completeness.
+    queryParams.set('skill_levels', JSON.stringify(skillLevels));
+    queryParams.set('chart_data', JSON.stringify(charts));
+
+    exportSkillProfileLink.href = `${window.location.origin}/view_skill_profile?${queryParams.toString()}`;
+    const shareableLink = `${window.location.origin}/view_skill_profile?${queryParams.toString()}`;
+    // exportSkillProfileLink.textContent = `Shareable Link: ${shareableLink}`;
+    exportSkillProfileLink.addEventListener('click', function (event) {
+      event.preventDefault();
+      navigator.clipboard.writeText(shareableLink).then(function() {
+        alert('Shareable link copied to clipboard!');
+      }, function(err) {
+        console.error('Could not copy text: ', err);
+      });
+    });
+  });
+</script>

--- a/main/templates/main/snippets/share_skill_profile_dropdown.html
+++ b/main/templates/main/snippets/share_skill_profile_dropdown.html
@@ -1,0 +1,30 @@
+<!-- Share dropdown -->
+<div class="dropdown nav d-none d-sm-block order-lg-3  justify-content-end">
+    <li class="nav-item d-flex align-items-center justify-content-end">
+        <a class="nav-link dropdown-toggle justify-content-end"
+           href="#"
+           data-bs-toggle="dropdown"
+           data-bs-auto-close="outside"
+           aria-expanded="false">Share</a>
+        <ul class="dropdown-menu">
+            <li>
+                <a class="dropdown-item export-skill-profile-link"
+                   id="shareable-link"
+                   href="#"
+                   target="_blank"
+                   rel="noopener noreferrer">Open Link <i aria-label="Copy sharable link" class="fa-solid fa-link"></i></a>
+            </li>
+            <li>
+                <button class="dropdown-item export-skill-profile-link-copy"
+                        id="copy-link-button">
+                    Copy Link <i aria-label="Copy sharable link" class="fa-solid fa-copy"></i>
+                </button>
+                {% include "main/snippets/create_user_skill_profile_link.html" %}
+            </li>
+            <li>
+                <button class="dropdown-item export-skill-profile" href="#">Export as CSV</button>
+                {% include "main/snippets/export_user_skill_profile.html" %}
+            </li>
+        </ul>
+    </li>
+</div>

--- a/main/templates/main/user-skills-profile.html
+++ b/main/templates/main/user-skills-profile.html
@@ -24,20 +24,24 @@
             <div class="col-lg-9 pb-2 pb-sm-4">
                 <section class="card border-0 mb-4">
                     <div class="card-body">
-                        <h1>Skills profile</h1>
-                        <p class="lead">
-                            Explore your skill levels in the Digital Research Competencies Framework
-                            using the interactive Skills Wheel. Each segment represents a competency,
-                            with size according to your self-assessed level.
-                        </p>
-                        <div id="dataviz_root" style="width:100%"></div>
-                        {% include "main/snippets/skill-wheel.html" %}
-                        <button class="export-skill-profile btn btn-primary mt-4">Export as CSV</button>
-                        {% include "main/snippets/export_user_skill_profile.html" %}
-                        <button class="export-skill-profile-link btn btn-secondary mt-4">Generate shareable link</button>
-                        {% include "main/snippets/create_user_skill_profile_link.html" %}
-                    </div>
-                </section>
+                        <div class="row">
+                            <div class="col-8">
+                                <h1>Skills profile</h1>
+                            </div>
+                            <div class="col-4 text-md-end justify-content-end">
+                                <!-- Share dropdown -->
+                                {% include "main/snippets/share_skill_profile_dropdown.html" %}
+                            </div>
+                            <p class="lead">
+                                Explore your skill levels in the Digital Research Competencies Framework
+                                using the interactive Skills Wheel. Each segment represents a competency,
+                                with size according to your self-assessed level.
+                            </p>
+                            <div id="dataviz_root" style="width:100%"></div>
+                            {% include "main/snippets/skill-wheel.html" %}
+                        </div>
+                    </section>
+                </div>
             </div>
         </div>
     </section>

--- a/main/urls.py
+++ b/main/urls.py
@@ -66,4 +66,9 @@ urlpatterns = [
     path("get-involved/", views.GetInvolvedPageView.as_view(), name="get_involved"),
     path("events/", views.EventsPageView.as_view(), name="events"),
     path("framework-json/", views.FrameworkView.as_view(), name="framework_json"),
+    path(
+        "view_skill_profile/",
+        views.ViewSkillProfilePageView.as_view(),
+        name="view_skill_profile",
+    ),
 ]

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -328,12 +328,11 @@ class ViewSkillProfilePageView(TemplateView):
     def get_context_data(self, **kwargs: Mapping[str, Any]) -> dict[str, Any]:
         """Add skill profile data from query parameters to the context."""
         context = super().get_context_data(**kwargs)
-        chart_data_json = self.request.GET.get("chart_data", "[]")
-        skill_levels_json = self.request.GET.get("skill_levels", "[]")
+
+        chart_data_json = nh3.clean(self.request.GET.get("chart_data", "[]"))
+        skill_levels_json = nh3.clean(self.request.GET.get("skill_levels", "[]"))
 
         try:
-            # TODO: We should validate this data more robustly before rendering
-            # it in the template
             context["chart_data"] = json.loads(chart_data_json)
             context["skill_levels"] = json.loads(skill_levels_json)
         except json.JSONDecodeError:

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -336,8 +336,8 @@ class ViewSkillProfilePageView(TemplateView):
             context["chart_data"] = json.loads(chart_data_json)
             context["skill_levels"] = json.loads(skill_levels_json)
         except json.JSONDecodeError:
-            logger.error("Invalid JSON in query parameters")
             context["chart_data"] = []
             context["skill_levels"] = []
+            context["error_message"] = "Invalid data provided in query parameters."
 
         return context

--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -318,3 +318,27 @@ class LicensingPageView(GitHubMarkdownPageView):
     github_raw_url = (
         "https://raw.githubusercontent.com/direct-framework/.github/main/LICENSING.md"
     )
+
+
+class ViewSkillProfilePageView(TemplateView):
+    """View that renders a shared skill profile based on query parameters."""
+
+    template_name = "main/shared-skills-profile.html"
+
+    def get_context_data(self, **kwargs: Mapping[str, Any]) -> dict[str, Any]:
+        """Add skill profile data from query parameters to the context."""
+        context = super().get_context_data(**kwargs)
+        chart_data_json = self.request.GET.get("chart_data", "[]")
+        skill_levels_json = self.request.GET.get("skill_levels", "[]")
+
+        try:
+            # TODO: We should validate this data more robustly before rendering
+            # it in the template
+            context["chart_data"] = json.loads(chart_data_json)
+            context["skill_levels"] = json.loads(skill_levels_json)
+        except json.JSONDecodeError:
+            logger.error("Invalid JSON in query parameters")
+            context["chart_data"] = []
+            context["skill_levels"] = []
+
+        return context

--- a/tests/main/test_main_views.py
+++ b/tests/main/test_main_views.py
@@ -565,3 +565,12 @@ class TestLicensingPageView(TemplateOkMixin):
 
     def _get_url(self):
         return reverse("licensing")
+
+
+class TestViewSkillProfilePageView(TemplateOkMixin):
+    """Test suite for the ViewSkillProfilePageView."""
+
+    _template_name = "main/shared-skills-profile.html"
+
+    def _get_url(self):
+        return reverse("view_skill_profile")


### PR DESCRIPTION
# Description

This implements a "Get shareable link" button next to the export as csv button on a users skill wheel page.
Following the url takes you to a publicly accessible anonymous view of the exported skill wheel data.

Screenshot of public view: 
<img width="762" height="776" alt="image" src="https://github.com/user-attachments/assets/729580bb-02a7-4a75-8aa2-e34e7503482c" />

Screenshot of user view:
<img width="1027" height="804" alt="image" src="https://github.com/user-attachments/assets/330dd28c-7a3e-426e-a163-880c6ce77868" />

It needs the following before being merged:
- [x] The json data from the query string should be sanitized
- [x] Needs some tests for the new view


Part of #742  (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
