### PR TITLE
Add acknowledgements section for discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ This project includes an NPM-based setup for managing front-end assets like styl
 
 See [Frontend Node](node/README.md) for details on working with the NPM-based frontend asset pipeline.
 
+## Acknowledgements
+
+_This work was supported by the [DisCouRSE Network+](https://discourse-network.github.io/), which received funding through the UKRI
+Digital Research Infrastructure Programme_
+
 ## Contributors
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
# Description

We've been asked to include an acknowledgment to DisCouRSE - following their [Social Media Guidelines](https://discourse-network.github.io/assets/docs/Social-Media-Guidelines-Funded-Projects.pdf)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Technical work (non-breaking, change which is work as part of a new feature)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
