### PR TITLE
Fix URL to point to LICENSE.md instead of LICENSING.md

### DIFF
--- a/main/views/page_views.py
+++ b/main/views/page_views.py
@@ -316,7 +316,7 @@ class LicensingPageView(GitHubMarkdownPageView):
     unavailable_message = "Licensing document is temporarily unavailable."
 
     github_raw_url = (
-        "https://raw.githubusercontent.com/direct-framework/.github/main/LICENSING.md"
+        "https://raw.githubusercontent.com/direct-framework/.github/main/LICENSE.md"
     )
 
 


### PR DESCRIPTION
Fix URL to point to LICENSE.md instead of LICENSING.md